### PR TITLE
fix: allow themed buttons in header

### DIFF
--- a/packages/antwerp-ui/react-components/src/lib/organisms/header/Header.tsx
+++ b/packages/antwerp-ui/react-components/src/lib/organisms/header/Header.tsx
@@ -27,7 +27,7 @@ export function Header({ logoHref, logoAlt, menuItems, logoSrc, skipToMainLabel,
                 }
               />
             ) : (
-              <Button {...m} key={m.id} emphasis="low" theme="neutral" className="o-header__button">
+              <Button emphasis="low" theme="neutral" {...m} key={m.id} className="o-header__button">
                 {m.label}
               </Button>
             )


### PR DESCRIPTION
Allow themed buttons in the header, so for example users can have a primary button in the header